### PR TITLE
Automatically answer common questions in the questions for staff channel

### DIFF
--- a/cogs/auto_question_answer.py
+++ b/cogs/auto_question_answer.py
@@ -29,7 +29,7 @@ class AutoQuestionAnswer(commands.Cog):
                                               colour=discord.Colour(0x358bbb))
                         if question.get("image"):
                             embed.set_image(url=question.get("image"))
-                        embed.set_footer(text="If this didn't help, press ❌. If it did press ✅")
+                        embed.set_footer(text="If this didn't help, press ❌. If it did press ✅ to mark it as accepted answer")
                         response_message = await message.channel.send(embed=embed)
                         await response_message.add_reaction("❌")
                         await response_message.add_reaction("✅")
@@ -37,18 +37,22 @@ class AutoQuestionAnswer(commands.Cog):
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction: discord.Reaction, user: discord.Member):
-        # Message is from bot and react is not from bot and in correct channel
-        if reaction.message.author.id == self.bot.user.id and user.id != self.bot.user.id and reaction.message.channel.id == 701451588593647628:
-            # React is for deleting the message
-            if reaction.emoji == "❌":
-                # Get old embed and change color to red
-                embed = reaction.message.embeds[0]
-                embed.colour = discord.Colour(0xf1370f)
-                await reaction.message.edit(embed=embed)
-                # Wait 1.25 seconds because the deletion is kinda jarring otherwise
-                await reaction.message.delete(delay=1.25)
-            elif reaction.emoji == "✅":
-                # Get old embed and change color to green
-                embed = reaction.message.embeds[0]
-                embed.colour = discord.Colour(0x0fc704)
-                await reaction.message.edit(embed=embed)
+        # Message is in correct channel
+        if reaction.message.channel.id in list(self.config.auto_question_answer["question_channels"].values()):
+            # Message is from bot and react is not from bot and in correct channel
+            if reaction.message.author.id == self.bot.user.id and user.id != self.bot.user.id:
+                # React is for deleting the message
+                if reaction.emoji == "❌":
+                    # Get old embed and change color to red
+                    embed = reaction.message.embeds[0]
+                    embed.colour = discord.Colour(0xf1370f)
+                    await reaction.message.edit(embed=embed)
+                    await reaction.message.clear_reactions()
+                    # Wait 1.25 seconds because the deletion is kinda jarring otherwise
+                    await reaction.message.delete(delay=1.25)
+                elif reaction.emoji == "✅":
+                    # Get old embed and change color to green
+                    embed = reaction.message.embeds[0]
+                    embed.colour = discord.Colour(0x0fc704)
+                    await reaction.message.edit(embed=embed)
+                    await reaction.message.clear_reactions()

--- a/cogs/auto_question_answer.py
+++ b/cogs/auto_question_answer.py
@@ -1,0 +1,54 @@
+import logging
+import discord
+from discord.ext import commands
+import helpers
+import re
+
+
+class AutoQuestionAnswer(commands.Cog):
+    """
+    Automatically attempts to answer common questions
+    """
+    def __init__(self, bot: commands.Bot, config: helpers.Config, log: logging.Logger):
+        self.bot = bot
+        self.config = config
+        self.log = log
+        self.log.info("Loaded Cog AutoQuestionAnswer")
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        # Message is not from self or another bot and in correct channel
+        if message.author != self.bot.user and message.author.bot is not True and message.channel.id in list(self.config.auto_question_answer["question_channels"].values()):
+            # Message not from a staff member
+            author_role_ids = [role.id for role in message.author.roles]
+            if not any([role_id for role_id in author_role_ids if role_id in list(self.config.auto_question_answer["staff_roles"].values())]):
+                for question in self.config.auto_question_answer["questions"]:
+                    if re.search(question["match"], message.content, re.IGNORECASE):
+                        embed = discord.Embed(title=f"This might help: {question['title']}",
+                                              description=question["description"],
+                                              colour=discord.Colour(0x358bbb))
+                        if question.get("image"):
+                            embed.set_image(url=question.get("image"))
+                        embed.set_footer(text="If this didn't help, press ❌. If it did press ✅")
+                        response_message = await message.channel.send(embed=embed)
+                        await response_message.add_reaction("❌")
+                        await response_message.add_reaction("✅")
+                        return
+
+    @commands.Cog.listener()
+    async def on_reaction_add(self, reaction: discord.Reaction, user: discord.Member):
+        # Message is from bot and react is not from bot and in correct channel
+        if reaction.message.author.id == self.bot.user.id and user.id != self.bot.user.id and reaction.message.channel.id == 701451588593647628:
+            # React is for deleting the message
+            if reaction.emoji == "❌":
+                # Get old embed and change color to red
+                embed = reaction.message.embeds[0]
+                embed.colour = discord.Colour(0xf1370f)
+                await reaction.message.edit(embed=embed)
+                # Wait 1.25 seconds because the deletion is kinda jarring otherwise
+                await reaction.message.delete(delay=1.25)
+            elif reaction.emoji == "✅":
+                # Get old embed and change color to green
+                embed = reaction.message.embeds[0]
+                embed.colour = discord.Colour(0x0fc704)
+                await reaction.message.edit(embed=embed)

--- a/cogs/auto_question_answer.py
+++ b/cogs/auto_question_answer.py
@@ -29,7 +29,7 @@ class AutoQuestionAnswer(commands.Cog):
                                               colour=discord.Colour(0x358bbb))
                         if question.get("image"):
                             embed.set_image(url=question.get("image"))
-                        embed.set_footer(text="If this didn't help, press ❌. If it did press ✅ to mark it as accepted answer")
+                        embed.set_footer(text=f"If this didn't help, press ❌. If it did press ✅ to mark it as correct | {message.id}")
                         response_message = await message.channel.send(embed=embed)
                         await response_message.add_reaction("❌")
                         await response_message.add_reaction("✅")
@@ -41,18 +41,33 @@ class AutoQuestionAnswer(commands.Cog):
         if reaction.message.channel.id in list(self.config.auto_question_answer["question_channels"].values()):
             # Message is from bot and react is not from bot and in correct channel
             if reaction.message.author.id == self.bot.user.id and user.id != self.bot.user.id:
-                # React is for deleting the message
-                if reaction.emoji == "❌":
-                    # Get old embed and change color to red
-                    embed = reaction.message.embeds[0]
-                    embed.colour = discord.Colour(0xf1370f)
-                    await reaction.message.edit(embed=embed)
-                    await reaction.message.clear_reactions()
-                    # Wait 1.25 seconds because the deletion is kinda jarring otherwise
-                    await reaction.message.delete(delay=1.25)
-                elif reaction.emoji == "✅":
-                    # Get old embed and change color to green
-                    embed = reaction.message.embeds[0]
-                    embed.colour = discord.Colour(0x0fc704)
-                    await reaction.message.edit(embed=embed)
-                    await reaction.message.clear_reactions()
+                # Get the embed of the bot message
+                embed = reaction.message.embeds[0]
+                # Get the authors roles
+                author_role_ids = [role.id for role in user.roles]
+                # Get the original message the bot responded to
+                original_message = await reaction.message.channel.fetch_message(int(embed.footer.text.split("|")[1]))
+                # If the reactant has any staff role or is the author of the question we can proceed
+                if any([role_id for role_id in author_role_ids if role_id in list(self.config.auto_question_answer["staff_roles"].values())]) or original_message.author.id == user.id:
+                    # React is for deleting the message
+                    if reaction.emoji == "❌":
+                        # Get old embed and change color to red
+                        embed.colour = discord.Colour(0xf1370f)
+                        await reaction.message.edit(embed=embed)
+                        await reaction.message.clear_reactions()
+                        # Wait 1.25 seconds because the deletion is kinda jarring otherwise
+                        await reaction.message.delete(delay=1.25)
+                    # React is for marking as correct response
+                    elif reaction.emoji == "✅":
+                        # Get old embed and change color to green
+                        embed.colour = discord.Colour(0x0fc704)
+                        embed.set_footer(text=f"Mark as accepted answer | {original_message.id}")
+                        await reaction.message.edit(embed=embed)
+                        await reaction.message.clear_reactions()
+                    # Reaction is spam, remove
+                    else:
+                        await reaction.remove(user)
+
+                # If they don't, remove the reaction
+                else:
+                    await reaction.remove(user)

--- a/config-prod.json
+++ b/config-prod.json
@@ -205,6 +205,11 @@
         "title": "When do pugs happen?",
         "description": "Pugs happen 4 days a week, to find out when pugs happen next check our <#701452458152689744>. Here's an overview:",
         "image": "https://i.imgur.com/4zl76e9.png"
+      },
+      {
+        "match": "(how.{0,15}join)",
+        "title": "How do I PUG?",
+        "description": "To join a PUG, look to see which lobby and voice channel you should join based on your SR. You can view the lobbies in <#504044585174040576>, <#504044584351957002> or <#506604689307992074>. Join the voice channel, with your mic muted if a game is going on, and post your battletag in <#506026271688622080>, <#647463638399057950> or <#647456585135685643> respectively.\nMake sure all letters, numbers and capitalizations are correct, and that you are in-game and ready to receive an invite. Ask your lobby leader politely for an invitation to the in-game lobby once any ongoing game is finished."
       }
     ],
     "question_channels": {

--- a/config-prod.json
+++ b/config-prod.json
@@ -180,5 +180,35 @@
       "public_required": true,
       "level_25_required": true
     }
-  ]
+  ],
+  "auto_question_answer": {
+    "staff_roles": {
+      "Pug Boss": 506682236821831682,
+      "PUG Admin": 505572593374330882,
+      "PUG Moderator": 504040405826928663,
+      "PC PUG Staff": 504040406414131201,
+      "PS4 PUG Staff": 514473025354203161,
+      "Xbox PUG Staff": 514471348232257536,
+      "Community Moderator": 504222907254308864,
+      "Elo Hell Director": 623716884222836737,
+      "Elo Hell Staff": 579996883234062366,
+      "Senior Community Mod": 504040403096436776
+    },
+    "questions": [
+      {
+        "match": "(coach)|(beginner)",
+        "title": "How do coached PUGs work?",
+        "description": "These are PUGs that we organize for players who are Gold and below, both teams are selected by a coach, who will give advice and feedback during pauses in the game. The goal of Coached PUGs is to help players improve.\nTo get access to **Coached PUGs** verify that you meet the requirements below and send screenshots of the current and last 2 seasons of competitive to a moderator or admin as proof.\n```- Account level must at least be level 100.\n- Players must have placed this season.\n- Players need to be ranked Gold or below.\n- Gold players need to have a season high that is below 2750 SR in the current and previous 2 seasons, this SR cap does not apply to players in Silver or Bronze. You will provide screenshots of these seasons as proof of this.\n- Players will only be allowed to play on roles they are currently below 2500 SR on.```"
+      },
+      {
+        "match": "(pug(s?) today)|(when.{1,15}pug)|(schedule)|(next.{1,15}pug)|(time.{1,15}pugs)",
+        "title": "When do pugs happen?",
+        "description": "Pugs happen 4 days a week, to find out when pugs happen next check our <#701452458152689744>. Here's an overview:",
+        "image": "https://i.imgur.com/4zl76e9.png"
+      }
+    ],
+    "question_channels": {
+      "questions-for-staff": 701451588593647628
+    }
+  }
 }

--- a/config-prod.json
+++ b/config-prod.json
@@ -201,7 +201,7 @@
         "description": "These are PUGs that we organize for players who are Gold and below, both teams are selected by a coach, who will give advice and feedback during pauses in the game. The goal of Coached PUGs is to help players improve.\nTo get access to **Coached PUGs** verify that you meet the requirements below and send screenshots of the current and last 2 seasons of competitive to a moderator or admin as proof.\n```- Account level must at least be level 100.\n- Players must have placed this season.\n- Players need to be ranked Gold or below.\n- Gold players need to have a season high that is below 2750 SR in the current and previous 2 seasons, this SR cap does not apply to players in Silver or Bronze. You will provide screenshots of these seasons as proof of this.\n- Players will only be allowed to play on roles they are currently below 2500 SR on.```"
       },
       {
-        "match": "(pug(s?) today)|(when.{1,15}pug)|(schedule)|(next.{1,15}pug)|(time.{1,15}pugs)",
+        "match": "(pug(s?) today)|(when.{1,15}pug)|(schedule)|(next.{1,15}pug)|(time.{1,15}pugs)|(pugs.{1,20}now)",
         "title": "When do pugs happen?",
         "description": "Pugs happen 4 days a week, to find out when pugs happen next check our <#701452458152689744>. Here's an overview:",
         "image": "https://i.imgur.com/4zl76e9.png"
@@ -210,6 +210,16 @@
         "match": "(how.{0,15}join)",
         "title": "How do I PUG?",
         "description": "To join a PUG, look to see which lobby and voice channel you should join based on your SR. You can view the lobbies in <#504044585174040576>, <#504044584351957002> or <#506604689307992074>. Join the voice channel, with your mic muted if a game is going on, and post your battletag in <#506026271688622080>, <#647463638399057950> or <#647456585135685643> respectively.\nMake sure all letters, numbers and capitalizations are correct, and that you are in-game and ready to receive an invite. Ask your lobby leader politely for an invitation to the in-game lobby once any ongoing game is finished."
+      },
+      {
+        "match": "(console)|(xbox)|(ps4)|(playstation)",
+        "title": "How do console PUGs work?",
+        "description":"**Xbox PUGs**\n\nAnnouncements will go out as normal in the #xbox-announce channel where people are expected to react if interested in participating. \nXbox Parties will be made/hosted on the Elo Hell Xbox PUGs Xbox Club for each lobby. Xbox PUG staff/Vets hosting the PUG will direct people as to which party to join.\n\n**PS4 PUGs**\n\nThere will be two announcements, a 1 hour heads up to let you know PUGs are going ahead, and an announcement when the PUG begins. These announcements will let you know who the lobby host will be, make sure to add the host when they post their account name. The lobby host will open a lobby named “Elo Hell PUGs” and set it to friends only, you can either join from the lobby browser or ask them for an invite. The lobby host will invite 2 captains to a private party and build teams and choose a map. The match will begin shortly after map picks."
+      },
+      {
+        "match": "(oceanic)|(oce)",
+        "title": "Are there Oceanic PUGs?",
+        "description": "Unfortunately, due to low demand we do not run Oceanic PUGs. However, feel free to join NA or EU PUGs."
       }
     ],
     "question_channels": {

--- a/helpers.py
+++ b/helpers.py
@@ -24,6 +24,7 @@ class Config:
         self.reacts_required = self.config_object["reacts_required"]
         self.delete_match_regex = self.config_object["delete_match_regex"]
         self.warn_wrong_battletags = self.config_object["warn_wrong_battletags"]
+        self.auto_question_answer = self.config_object["auto_question_answer"]
 
 
 def log_message_deletes(messages: List[discord.Message], action_name: str, log: logging.Logger):

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from helpers import Config
 import logging
 
 from discord_handler import DiscordHandler
-from cogs import clean_old_messages, ping_for_messages, disable_reacts, vet_ping_unofficials, purge_channel, reacts_required, delete_match_regex, initialize, warn_wrong_battletags
+from cogs import clean_old_messages, ping_for_messages, disable_reacts, vet_ping_unofficials, purge_channel, reacts_required, delete_match_regex, initialize, warn_wrong_battletags, auto_question_answer
 
 
 def main():
@@ -47,6 +47,7 @@ def main():
     bot.add_cog(reacts_required.ReactsRequired(bot, config, log))
     bot.add_cog(delete_match_regex.DeleteMatchRegEx(bot, config, log))
     bot.add_cog(warn_wrong_battletags.WarnWrongBattletags(bot, config, log))
+    bot.add_cog(auto_question_answer.AutoQuestionAnswer(bot, config, log))
     bot.add_cog(initialize.Initialize(bot, config, log))
 
     # Start bot


### PR DESCRIPTION
- Config defines common questions with a RegEx to identify messages with questions and a response to send
- Users can give positive or negative feedback, on negative feedback the message gets deleted, on positive feedback it turns green to show that the question was answered
- Messages from users with any staff role are ignored to stop the bot from annoying staff when they answer questions that the bot can't answer
![image](https://user-images.githubusercontent.com/23165606/80540528-cec95200-89a9-11ea-81e0-56c56febac30.png)
![image](https://user-images.githubusercontent.com/23165606/80540695-164fde00-89aa-11ea-9360-d874b8311405.png)
![image](https://user-images.githubusercontent.com/23165606/80540881-6e86e000-89aa-11ea-8663-0fe30eb084fc.png)


